### PR TITLE
[ISSUE #19] Make HEALPix/MOC support optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,14 @@ script:
   - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
   - pg_virtualenv make crushtest
   - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
+  - make clean
+  - make PROFILE="-Werror" USE_HEALPIX=0
+  - sudo make USE_HEALPIX=0 install
+  - pg_virtualenv make USE_HEALPIX=0 installcheck
+  - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
+  - pg_virtualenv make USE_HEALPIX=0 test
+  - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
+  - pg_virtualenv make USE_HEALPIX=0 crushtest
+  - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
   - make -C doc
   - sudo make -C doc install

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ script:
   - make PROFILE="-Werror"
   - sudo make install
   - pg_virtualenv make installcheck
-  - if test -s regression.diffs; then cat regression.diffs; fi
+  - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
+  - pg_virtualenv make test
+  - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
+  - pg_virtualenv make crushtest
+  - if test -s regression.diffs; then cat regression.diffs; exit 1; fi
   - make -C doc
   - sudo make -C doc install

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ pg_sphere--1.1.5beta4gavo--1.2.0.sql: pgs_moc_ops.sql.in
 	cat upgrade_scripts/$@.in $^ > $@
 
 pg_sphere--1.2.0--1.2.1.sql: pgs_moc_geo_casts.sql.in pgs_epochprop.sql.in
-	cat $^ > $@
+	cat upgrade_scripts/$@.in $^ > $@
 
 pg_sphere--1.2.1--1.2.2.sql: upgrade_scripts/pg_sphere--1.2.1--1.2.2-healpix.sql.in
 	cat upgrade_scripts/$@.in $^ > $@

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ else
 endif
 
 test: pg_sphere.test.sql sql/init_test.sql
+	cp expected/init_test.out.in expected/init_test.out
+ifneq ($(USE_HEALPIX),0)
+	cat expected/init_test_healpix.out.in >> expected/init_test.out
+endif
 	$(pg_regress_installcheck) $(PGS_TMP_DIR) $(REGRESS_OPTS) $(TESTS)
 
 pg_sphere.test.sql: $(RELEASE_SQL) $(shlib)

--- a/Makefile
+++ b/Makefile
@@ -30,24 +30,21 @@ DATA_built  = $(RELEASE_SQL) \
 
 DOCS        = README.pg_sphere COPYRIGHT.pg_sphere
 REGRESS     = init tables points euler circle line ellipse poly path box index \
-              contains_ops contains_ops_compat bounding_box_gist gnomo
+              contains_ops contains_ops_compat bounding_box_gist gnomo epochprop
 
 ifneq ($(USE_HEALPIX),0)
 REGRESS    += healpix moc mocautocast
 endif
 
-REGRESS    += epochprop
-
 REGRESS_9_5 = index_9.5 # experimental for spoint3
 
 TESTS       = init_test tables points euler circle line ellipse poly path box \
-              index contains_ops contains_ops_compat bounding_box_gist gnomo
+              index contains_ops contains_ops_compat bounding_box_gist gnomo \
+              epochprop
 
 ifneq ($(USE_HEALPIX),0)
 TESTS      += healpix moc mocautocast
 endif
-
-TESTS      += epochprop
 
 PG_CFLAGS	+= -DPGSPHERE_VERSION=$(PGSPHERE_VERSION)
 PG_CPPFLAGS	+= -DPGSPHERE_VERSION=$(PGSPHERE_VERSION)
@@ -85,7 +82,7 @@ PGS_SQL_9_5 = pgs_9.5.sql # experimental for spoint3
 
 ifdef USE_PGXS
   ifndef PG_CONFIG
-    PG_CONFIG := pg_config
+    PG_CONFIG = pg_config
   endif
   PGXS := $(shell $(PG_CONFIG) --pgxs)
   include $(PGXS)
@@ -98,8 +95,8 @@ else
 endif
 
 ifneq ($(USE_HEALPIX),0)
-# compiler settings
-PKG_CONFIG = pkg-config
+# compiler settings for linking with libhealpix_cxx
+PKG_CONFIG ?= pkg-config
 override CPPFLAGS += $(shell $(PKG_CONFIG) --cflags healpix_cxx)
 SHLIB_LINK += $(shell $(PKG_CONFIG) --libs healpix_cxx)
 LINK.shared = g++ -shared
@@ -113,7 +110,6 @@ healpix_bare/healpix_bare.o : healpix_bare/healpix_bare.c
 pg_version := $(word 2,$(shell $(PG_CONFIG) --version))
 pg_version_9_5_plus = $(if $(filter-out 9.1% 9.2% 9.3% 9.4%,$(pg_version)),y,n)
 has_explain_summary = $(if $(filter-out 9.%,$(pg_version)),y,n)
-#
 
 ## the use of spoint 3 is too experimental and preliminary:
 #ifeq ($(pg_version_9_5_plus),y)
@@ -149,14 +145,14 @@ $(RELEASE_SQL): $(addsuffix .in, $(RELEASE_SQL) $(PGS_SQL))
 
 # for "create extension from unpacked*":
 
-UPGRADE_UNP_COMMON =  pgs_types.sql pgs_point.sql pgs_euler.sql pgs_circle.sql \
+UPGRADE_UNP_COMMON = pgs_types.sql pgs_point.sql pgs_euler.sql pgs_circle.sql \
 	pgs_line.sql pgs_ellipse.sql pgs_polygon.sql pgs_path.sql \
 	pgs_box.sql pgs_contains_ops_compat.sql pgs_gist.sql \
 	pgs_gist_contains_ops.sql contains-ops-fixes-1.sql
 
 AUGMENT_UNP_COMMON = upgrade_scripts/pgs_pre111.sql pgs_contains_ops.sql \
 	gnomo.sql
-# for vanilla 1.1.1 users
+# for vanilla 1.1.1 users:
 AUGMENT_UNP_111 = $(AUGMENT_UNP_COMMON) pgs_gist_pointkey.sql
 
 # for 1.1.2+ users: 'from unpacked_1.1.2plus'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 PGSPHERE_VERSION = 1.2.2
+EXTENSION        = pg_sphere
+RELEASE_SQL      = $(EXTENSION)--$(PGSPHERE_VERSION).sql
+USE_PGXS         = 1
+USE_HEALPIX      =? 1
 
 # the base dir name may be changed depending on git clone command
 SRC_DIR = $(shell basename $(shell pwd))
@@ -7,11 +11,13 @@ MODULE_big = pg_sphere
 OBJS       = src/sscan.o src/sparse.o src/sbuffer.o src/vector3d.o src/point.o \
              src/euler.o src/circle.o src/line.o src/ellipse.o src/polygon.o \
              src/path.o src/box.o src/output.o src/gq_cache.o src/gist.o \
-             src/key.o src/gnomo.o src/healpix.o src/moc.o src/process_moc.o \
-             healpix_bare/healpix_bare.o src/epochprop.o
+             src/key.o src/gnomo.o src/epochprop.o
 
-EXTENSION   = pg_sphere
-RELEASE_SQL = $(EXTENSION)--$(PGSPHERE_VERSION).sql
+ifneq ($(USE_HEALPIX),0)
+OBJS      += src/healpix.o src/moc.o src/process_moc.o \
+             healpix_bare/healpix_bare.o
+endif
+
 DATA_built  = $(RELEASE_SQL) \
 			  pg_sphere--unpackaged--1.1.5beta0gavo.sql \
 			  pg_sphere--1.0--1.0_gavo.sql \
@@ -24,14 +30,24 @@ DATA_built  = $(RELEASE_SQL) \
 
 DOCS        = README.pg_sphere COPYRIGHT.pg_sphere
 REGRESS     = init tables points euler circle line ellipse poly path box index \
-			  contains_ops contains_ops_compat bounding_box_gist gnomo healpix \
-			  moc mocautocast epochprop
+              contains_ops contains_ops_compat bounding_box_gist gnomo
+
+ifneq ($(USE_HEALPIX),0)
+REGRESS    += healpix moc mocautocast
+endif
+
+REGRESS    += epochprop
 
 REGRESS_9_5 = index_9.5 # experimental for spoint3
 
-TESTS       = init_test tables points euler circle line ellipse poly path box index \
-			  contains_ops contains_ops_compat bounding_box_gist gnomo healpix \
-			  moc mocautocast epochprop
+TESTS       = init_test tables points euler circle line ellipse poly path box \
+              index contains_ops contains_ops_compat bounding_box_gist gnomo
+
+ifneq ($(USE_HEALPIX),0)
+TESTS      += healpix moc mocautocast
+endif
+
+TESTS      += epochprop
 
 PG_CFLAGS	+= -DPGSPHERE_VERSION=$(PGSPHERE_VERSION)
 PG_CPPFLAGS	+= -DPGSPHERE_VERSION=$(PGSPHERE_VERSION)
@@ -48,14 +64,25 @@ CRUSH_TESTS = init_extended circle_extended
 
 # order of sql files is important
 PGS_SQL     = pgs_types.sql pgs_point.sql pgs_euler.sql pgs_circle.sql \
-   pgs_line.sql pgs_ellipse.sql pgs_polygon.sql pgs_path.sql \
-   pgs_box.sql pgs_contains_ops.sql pgs_contains_ops_compat.sql \
-   pgs_gist.sql gnomo.sql \
-   healpix.sql pgs_gist_spoint3.sql pgs_moc_type.sql pgs_moc_compat.sql pgs_moc_ops.sql \
-   pgs_moc_geo_casts.sql pgs_epochprop.sql
+              pgs_line.sql pgs_ellipse.sql pgs_polygon.sql pgs_path.sql \
+              pgs_box.sql pgs_contains_ops.sql pgs_contains_ops_compat.sql \
+              pgs_gist.sql gnomo.sql
+
+ifneq ($(USE_HEALPIX),0)
+PGS_SQL    += healpix.sql
+endif
+
+PGS_SQL    += pgs_gist_spoint3.sql
+
+ifneq ($(USE_HEALPIX),0)
+PGS_SQL    += pgs_moc_type.sql pgs_moc_compat.sql pgs_moc_ops.sql \
+              pgs_moc_geo_casts.sql
+endif
+
+PGS_SQL    += pgs_epochprop.sql
+
 PGS_SQL_9_5 = pgs_9.5.sql # experimental for spoint3
 
-USE_PGXS = 1
 ifdef USE_PGXS
   ifndef PG_CONFIG
     PG_CONFIG := pg_config
@@ -70,11 +97,13 @@ else
   include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
+ifneq ($(USE_HEALPIX),0)
 # compiler settings
 PKG_CONFIG = pkg-config
 override CPPFLAGS += $(shell $(PKG_CONFIG) --cflags healpix_cxx)
 SHLIB_LINK += $(shell $(PKG_CONFIG) --libs healpix_cxx)
 LINK.shared = g++ -shared
+endif
 
 # healpix_bare.c isn't ours so we refrain from fixing the warnings in there
 healpix_bare/healpix_bare.o : healpix_bare/healpix_bare.c
@@ -96,8 +125,10 @@ has_explain_summary = $(if $(filter-out 9.%,$(pg_version)),y,n)
 crushtest: REGRESS += $(CRUSH_TESTS)
 crushtest: installcheck
 
+ifneq ($(USE_HEALPIX),0)
 ifeq ($(has_explain_summary),y)
         REGRESS += moc1 moc100
+endif
 endif
 
 ifeq ($(pg_version_9_5_plus),y)
@@ -159,12 +190,17 @@ else
 endif
 
 # local stuff follows here
-
-AUGMENT_GAVO_111 = $(AUGMENT_UNP_111) healpix.sql # for vanilla 1.1.1 users
+AUGMENT_GAVO_111 = $(AUGMENT_UNP_111) # for vanilla 1.1.1 users
+ifneq ($(USE_HEALPIX),0)
+AUGMENT_GAVO_111 += healpix.sql
+endif
 UPGRADE_GAVO_111 = $(UPGRADE_UNP_COMMON)
 
-# add new Healpix functions and experimental spoint3
-AUGMENT_FROM_GAVO = healpix.sql pgs_gist_spoint3.sql
+# add new HEALPix functions and experimental spoint3
+ifneq ($(USE_HEALPIX),0)
+AUGMENT_FROM_GAVO = healpix.sql
+endif
+AUGMENT_FROM_GAVO += pgs_gist_spoint3.sql
 
 AUGMENT_UNP_115B0G = $(AUGMENT_UNP_111) $(AUGMENT_FROM_GAVO)
 UPGRADE_UNP_115B0G = $(UPGRADE_UNP_COMMON)
@@ -188,6 +224,7 @@ pg_sphere--1.0_gavo--1.1.5beta0gavo.sql: $(addsuffix .in, \
 		$(addprefix upgrade_scripts/, $(UPGRADE_1_0_115B0G)))
 	cat upgrade_scripts/$@.in $^ > $@
 
+ifneq ($(USE_HEALPIX),0)
 pg_sphere--1.1.5beta0gavo--1.1.5beta2gavo.sql: pgs_moc_type.sql.in
 	cat upgrade_scripts/$@.in $^ > $@
 
@@ -195,13 +232,29 @@ pg_sphere--1.1.5beta2gavo--1.1.5beta4gavo.sql: pgs_moc_compat.sql.in
 	cat upgrade_scripts/$@.in $^ > $@
 
 pg_sphere--1.1.5beta4gavo--1.2.0.sql: pgs_moc_ops.sql.in
-	cat $^ > $@
+	cat upgrade_scripts/$@.in $^ > $@
 
 pg_sphere--1.2.0--1.2.1.sql: pgs_moc_geo_casts.sql.in pgs_epochprop.sql.in
 	cat $^ > $@
 
-pg_sphere--1.2.1--1.2.2.sql: upgrade_scripts/pg_sphere--1.2.1--1.2.2.sql.in
-	cat $^ > $@
+pg_sphere--1.2.1--1.2.2.sql: upgrade_scripts/pg_sphere--1.2.1--1.2.2-healpix.sql.in
+	cat upgrade_scripts/$@.in $^ > $@
+else
+pg_sphere--1.1.5beta0gavo--1.1.5beta2gavo.sql:
+	cat upgrade_scripts/$@.in > $@
+
+pg_sphere--1.1.5beta2gavo--1.1.5beta4gavo.sql:
+	cat upgrade_scripts/$@.in > $@
+
+pg_sphere--1.1.5beta4gavo--1.2.0.sql:
+	cat upgrade_scripts/$@.in > $@
+
+pg_sphere--1.2.0--1.2.1.sql: pgs_epochprop.sql.in
+	cat upgrade_scripts/$@.in $^ > $@
+
+pg_sphere--1.2.1--1.2.2.sql:
+	cat upgrade_scripts/$@.in > $@
+endif
 
 # end of local stuff
 

--- a/README.pg_sphere
+++ b/README.pg_sphere
@@ -9,26 +9,25 @@ It provides:
 * Object rotation by Euler angles
 * Indexing of spherical data types
 
-This is an R-Tree implementation using GiST for spherical objects
-like spherical points and spherical circles with 
-useful functions and operators.
+This is an R-Tree implementation using GiST for spherical objects like
+spherical points and spherical circles with useful functions and operators.
 
 NOTICE:
-     This version will work only with PostgreSQL version 9.5 and above.
+     This version will work only with PostgreSQL version 9.6 and above.
 
 INSTALLATION:
 
   -- Build and install
 
-  gmake
-  gmake install
+  make
+  make install
 
   -- HEALPix/MOC support is included by default. If your platform does not
   -- have the required libhealpix_cxx dependency, you can optionally build
-  -- pgSphere without HEALPix/MOC support, like so:
+  -- pgSphere without HEALPix/MOC support, like this:
 
-  gmake USE_HEALPIX=0
-  gmake USE_HEALPIX=0 install
+  make USE_HEALPIX=0
+  make USE_HEALPIX=0 install
 
   -- Load extension
 
@@ -44,7 +43,7 @@ UPDATING AN EXISTING INSTALLATION:
 
   -- where A.B.C is a placeholder for the current version.
   -- You also may want to check what version of pgSphere is installed using
-     either of following commands:
+     either or both of the following commands:
 
   psql -c "SELECT pg_sphere_version();" <database>
   psql -c "SELECT * FROM pg_available_extension_versions WHERE name = 'pg_sphere';"
@@ -53,11 +52,20 @@ REGRESSION TEST (as the same user as the currently running PostgreSQL server):
 
   make installcheck
 
+  -- or --
+
+  make USE_HEALPIX=0 installcheck
+
 LONG REGRESSION TEST:
 
   make crushtest
 
-The 'make' program must be compatible with GNU make.
+  -- or --
+
+  make USE_HEALPIX=0 crushtest
+
+The 'make' program used in all of the above commands must be compatible with
+GNU make.
 
 For more information or to report issues or to help with development, please
 refer to https://github.com/postgrespro/pgsphere/

--- a/README.pg_sphere
+++ b/README.pg_sphere
@@ -46,7 +46,7 @@ UPDATING AN EXISTING INSTALLATION:
   -- You also may want to check what version of pgSphere is installed using
      either of following commands:
 
-  psql -c "select pg_sphere_version();" <database>
+  psql -c "SELECT pg_sphere_version();" <database>
   psql -c "SELECT * FROM pg_available_extension_versions WHERE name = 'pg_sphere';"
 
 REGRESSION TEST (as the same user as the currently running PostgreSQL server):

--- a/README.pg_sphere
+++ b/README.pg_sphere
@@ -14,28 +14,53 @@ like spherical points and spherical circles with
 useful functions and operators.
 
 NOTICE:
-     This version will work only with postgresql version 9.1 and above.
+     This version will work only with PostgreSQL version 9.5 and above.
 
 INSTALLATION:
 
-  -- build and install
-  gmake USE_PGXS=1 PG_CONFIG=/usr/bin/pg_config
-  gmake USE_PGXS=1 PG_CONFIG=/usr/bin/pg_config install
-  -- load extension
+  -- Build and install
+
+  gmake
+  gmake install
+
+  -- HEALPix/MOC support is included by default. If your platform does not
+  -- have the required libhealpix_cxx dependency, you can optionally build
+  -- pgSphere without HEALPix/MOC support, like so:
+
+  gmake USE_HEALPIX=0
+  gmake USE_HEALPIX=0 install
+
+  -- Load extension
+
   psql -c "CREATE EXTENSION pg_sphere;" <database>
 
-REGRESSION TEST (as the same user as the currently running postgresql server):
+UPDATING AN EXISTING INSTALLATION:
 
-  make USE_PGXS=1 installcheck
+  -- If you are updating from a previous version of pgSphere, perform the
+  -- same make and make install steps as above, but, instead of the CREATE
+  -- EXTENSION step, you need to do:
+
+  psql -c "ALTER EXTENSION q3c UPDATE TO 'A.B.C';" <database>
+
+  -- where A.B.C is a placeholder for the current version.
+  -- You also may want to check what version of pgSphere is installed using
+     either of following commands:
+
+  psql -c "select pg_sphere_version();" <database>
+  psql -c "SELECT * FROM pg_available_extension_versions WHERE name = 'pg_sphere';"
+
+REGRESSION TESTS (as the same user as the currently running PostgreSQL server):
+
+  make installcheck
+  make test
 
 LONG REGRESSION TEST:
 
-  make USE_PGXS=1 crushtest
+  make crushtest
 
 The 'make' program must be compatible with GNU make.
 
-For more information, have a look at http://pgsphere.projects.postgresql.org
-and https://github.com/akorotkov/pgsphere
+For more information or to report issues or to help with development, please
+refer to https://github.com/postgrespro/pgsphere/
 
 Have a lot of fun!
-

--- a/README.pg_sphere
+++ b/README.pg_sphere
@@ -49,10 +49,9 @@ UPDATING AN EXISTING INSTALLATION:
   psql -c "select pg_sphere_version();" <database>
   psql -c "SELECT * FROM pg_available_extension_versions WHERE name = 'pg_sphere';"
 
-REGRESSION TESTS (as the same user as the currently running PostgreSQL server):
+REGRESSION TEST (as the same user as the currently running PostgreSQL server):
 
   make installcheck
-  make test
 
 LONG REGRESSION TEST:
 
@@ -62,5 +61,7 @@ The 'make' program must be compatible with GNU make.
 
 For more information or to report issues or to help with development, please
 refer to https://github.com/postgrespro/pgsphere/
+
+Original repository for pgSphere: https://github.com/akorotkov/pgsphere
 
 Have a lot of fun!

--- a/expected/init_test.out.in
+++ b/expected/init_test.out.in
@@ -24,14 +24,12 @@ psql:pg_sphere.test.sql:159: NOTICE:  argument type spath is only a shell
 psql:pg_sphere.test.sql:178: NOTICE:  type "sbox" is not yet defined
 DETAIL:  Creating a shell type definition.
 psql:pg_sphere.test.sql:185: NOTICE:  argument type sbox is only a shell
-psql:pg_sphere.test.sql:8541: NOTICE:  type "spherekey" is not yet defined
+psql:pg_sphere.test.sql:8540: NOTICE:  type "spherekey" is not yet defined
 DETAIL:  Creating a shell type definition.
-psql:pg_sphere.test.sql:8548: NOTICE:  argument type spherekey is only a shell
-psql:pg_sphere.test.sql:8562: NOTICE:  type "pointkey" is not yet defined
+psql:pg_sphere.test.sql:8547: NOTICE:  argument type spherekey is only a shell
+psql:pg_sphere.test.sql:8561: NOTICE:  type "pointkey" is not yet defined
 DETAIL:  Creating a shell type definition.
-psql:pg_sphere.test.sql:8569: NOTICE:  argument type pointkey is only a shell
-psql:pg_sphere.test.sql:8575: NOTICE:  argument type pointkey is only a shell
-psql:pg_sphere.test.sql:8581: NOTICE:  argument type pointkey is only a shell
-psql:pg_sphere.test.sql:8587: NOTICE:  argument type pointkey is only a shell
-psql:pg_sphere.test.sql:9154: NOTICE:  return type smoc is only a shell
-psql:pg_sphere.test.sql:9160: NOTICE:  argument type smoc is only a shell
+psql:pg_sphere.test.sql:8568: NOTICE:  argument type pointkey is only a shell
+psql:pg_sphere.test.sql:8574: NOTICE:  argument type pointkey is only a shell
+psql:pg_sphere.test.sql:8580: NOTICE:  argument type pointkey is only a shell
+psql:pg_sphere.test.sql:8586: NOTICE:  argument type pointkey is only a shell

--- a/expected/init_test_healpix.out.in
+++ b/expected/init_test_healpix.out.in
@@ -1,0 +1,2 @@
+psql:pg_sphere.test.sql:9153: NOTICE:  return type smoc is only a shell
+psql:pg_sphere.test.sql:9159: NOTICE:  argument type smoc is only a shell

--- a/upgrade_scripts/pg_sphere--1.1.5beta4gavo--1.2.0.sql.in
+++ b/upgrade_scripts/pg_sphere--1.1.5beta4gavo--1.2.0.sql.in
@@ -1,0 +1,2 @@
+-- complain if this upgrade script is run via psql
+\echo Use "ALTER EXTENSION pg_sphere UPDATE TO '1.2.0'" to load this file. \quit

--- a/upgrade_scripts/pg_sphere--1.2.0--1.2.1.sql.in
+++ b/upgrade_scripts/pg_sphere--1.2.0--1.2.1.sql.in
@@ -1,0 +1,2 @@
+-- complain if this upgrade script is run via psql
+\echo Use "ALTER EXTENSION pg_sphere UPDATE TO '1.2.1'" to load this file. \quit

--- a/upgrade_scripts/pg_sphere--1.2.1--1.2.2-healpix.sql.in
+++ b/upgrade_scripts/pg_sphere--1.2.1--1.2.2-healpix.sql.in
@@ -1,0 +1,30 @@
+-- healpix
+ALTER FUNCTION nest2ring(integer, bigint) PARALLEL SAFE;
+ALTER FUNCTION ring2nest(integer, bigint) PARALLEL SAFE;
+ALTER FUNCTION healpix_convert_nest(integer, integer, bigint) PARALLEL SAFE;
+ALTER FUNCTION healpix_convert_ring(integer, integer, bigint) PARALLEL SAFE;
+ALTER FUNCTION nside2order(bigint) PARALLEL SAFE;
+ALTER FUNCTION order2nside(integer) PARALLEL SAFE;
+ALTER FUNCTION nside2npix(bigint) PARALLEL SAFE;
+ALTER FUNCTION npix2nside(bigint) PARALLEL SAFE;
+ALTER FUNCTION healpix_nest(integer, spoint) PARALLEL SAFE;
+ALTER FUNCTION healpix_ring(integer, spoint) PARALLEL SAFE;
+ALTER FUNCTION centre_of_healpix_nest(integer, bigint) PARALLEL SAFE;
+ALTER FUNCTION centre_of_healpix_ring(integer, bigint) PARALLEL SAFE;
+ALTER FUNCTION center_of_healpix_nest(integer, bigint) PARALLEL SAFE;
+ALTER FUNCTION center_of_healpix_ring(integer, bigint) PARALLEL SAFE;
+
+-- moc_type
+ALTER FUNCTION smoc_in(cstring) PARALLEL SAFE;
+ALTER FUNCTION smoc_out(smoc) PARALLEL SAFE;
+ALTER FUNCTION moc_debug() PARALLEL SAFE;
+ALTER FUNCTION set_smoc_output_type(integer) PARALLEL SAFE;
+ALTER FUNCTION max_order(smoc) PARALLEL SAFE;
+ALTER FUNCTION healpix_subset_smoc(bigint, smoc) PARALLEL SAFE;
+ALTER FUNCTION healpix_not_subset_smoc(bigint, smoc) PARALLEL SAFE;
+ALTER FUNCTION smoc_superset_healpix(smoc, bigint) PARALLEL SAFE;
+ALTER FUNCTION smoc_not_superset_healpix(smoc, bigint) PARALLEL SAFE;
+ALTER FUNCTION spoint_subset_smoc(spoint, smoc) PARALLEL SAFE;
+ALTER FUNCTION spoint_not_subset_smoc(spoint, smoc) PARALLEL SAFE;
+ALTER FUNCTION smoc_superset_spoint(smoc, spoint) PARALLEL SAFE;
+ALTER FUNCTION smoc_not_superset_spoint(smoc, spoint) PARALLEL SAFE;

--- a/upgrade_scripts/pg_sphere--1.2.1--1.2.2.sql.in
+++ b/upgrade_scripts/pg_sphere--1.2.1--1.2.2.sql.in
@@ -2,22 +2,6 @@
 ALTER FUNCTION gnomonic_proj(spoint, spoint) PARALLEL SAFE;
 ALTER FUNCTION gnomonic_inv(point, spoint) PARALLEL SAFE;
 
--- healpix
-ALTER FUNCTION nest2ring(integer, bigint) PARALLEL SAFE;
-ALTER FUNCTION ring2nest(integer, bigint) PARALLEL SAFE;
-ALTER FUNCTION healpix_convert_nest(integer, integer, bigint) PARALLEL SAFE;
-ALTER FUNCTION healpix_convert_ring(integer, integer, bigint) PARALLEL SAFE;
-ALTER FUNCTION nside2order(bigint) PARALLEL SAFE;
-ALTER FUNCTION order2nside(integer) PARALLEL SAFE;
-ALTER FUNCTION nside2npix(bigint) PARALLEL SAFE;
-ALTER FUNCTION npix2nside(bigint) PARALLEL SAFE;
-ALTER FUNCTION healpix_nest(integer, spoint) PARALLEL SAFE;
-ALTER FUNCTION healpix_ring(integer, spoint) PARALLEL SAFE;
-ALTER FUNCTION centre_of_healpix_nest(integer, bigint) PARALLEL SAFE;
-ALTER FUNCTION centre_of_healpix_ring(integer, bigint) PARALLEL SAFE;
-ALTER FUNCTION center_of_healpix_nest(integer, bigint) PARALLEL SAFE;
-ALTER FUNCTION center_of_healpix_ring(integer, bigint) PARALLEL SAFE;
-
 -- sbox
 ALTER FUNCTION sbox(spoint, spoint) PARALLEL SAFE;
 ALTER FUNCTION sw(sbox) PARALLEL SAFE;
@@ -215,21 +199,6 @@ ALTER FUNCTION scircle_contains_line_com(sline, scircle) PARALLEL SAFE;
 ALTER FUNCTION scircle_contains_line_neg(scircle, sline) PARALLEL SAFE;
 ALTER FUNCTION scircle_contains_line_com_neg(sline, scircle) PARALLEL SAFE;
 
--- moc_type
-ALTER FUNCTION smoc_in(cstring) PARALLEL SAFE;
-ALTER FUNCTION smoc_out(smoc) PARALLEL SAFE;
-ALTER FUNCTION moc_debug() PARALLEL SAFE;
-ALTER FUNCTION set_smoc_output_type(integer) PARALLEL SAFE;
-ALTER FUNCTION max_order(smoc) PARALLEL SAFE;
-ALTER FUNCTION healpix_subset_smoc(bigint, smoc) PARALLEL SAFE;
-ALTER FUNCTION healpix_not_subset_smoc(bigint, smoc) PARALLEL SAFE;
-ALTER FUNCTION smoc_superset_healpix(smoc, bigint) PARALLEL SAFE;
-ALTER FUNCTION smoc_not_superset_healpix(smoc, bigint) PARALLEL SAFE;
-ALTER FUNCTION spoint_subset_smoc(spoint, smoc) PARALLEL SAFE;
-ALTER FUNCTION spoint_not_subset_smoc(spoint, smoc) PARALLEL SAFE;
-ALTER FUNCTION smoc_superset_spoint(smoc, spoint) PARALLEL SAFE;
-ALTER FUNCTION smoc_not_superset_spoint(smoc, spoint) PARALLEL SAFE;
-
 -- spath
 ALTER FUNCTION npoints(spath) PARALLEL SAFE;
 ALTER FUNCTION spoint(spath, int4) PARALLEL SAFE;
@@ -344,4 +313,5 @@ ALTER FUNCTION spoly_add_points_fin_aggr(spoly) PARALLEL SAFE;
 
 -- gist_spoint3
 ALTER FUNCTION g_spoint3_penalty(internal, internal, internal) PARALLEL SAFE;
-ALTER FUNCTION g_spoint3_fetch(internal, internal, internal) PARALLEL SAFE;
+ALTER FUNCTION g_spoint3_fetch(internal) PARALLEL SAFE;
+


### PR DESCRIPTION
This PR address issue #19 and makes support for HEALPix/MOC functionality optional. It is enabled by default, but it can be disabled by including `USE_HEALPIX=0` as an argument to the `make` commands. The README.pg_sphere file is updated to reflect this change (and other recent changes to the build process).

Also, when upgrading my installation from 1.2.1 to 1.2.2, I was getting the error:
```
# ALTER EXTENSION pg_sphere UPDATE TO '1.2.2';
ERROR:  function g_spoint3_fetch(internal, internal, internal) does not exist
```
I've included a fix for that in this PR (the function is just `g_spoint3_fetch(internal)`). Let me know if you prefer that I submit that as a separate PR.