### PR TITLE
Add pipeline for docs using GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,51 @@
+name: Build and Deploy Docs
+
+# Deploy docs only for master
+on:
+  push:
+    branches:
+      - "master"
+
+# Allow deployment to GitHub Pages
+permissions:
+  pages: write
+  id-token: write
+
+jobs:
+  deploy-docs:
+
+    name: Deploy Docs
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y \
+          docbook-xml \
+          docbook-xsl \
+          libxml2-utils \
+          xsltproc \
+          fop
+
+    - name: Clone pgSphere
+      uses: actions/checkout@v4
+
+    - name: Build docs
+      run: make -C doc
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v2
+      with:
+        path: 'doc/html'
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2


### PR DESCRIPTION
Build and deploy docs to GitHub Pages. This workflow will deploy for master branch. For now, it hosts doc/html directory, so only the last version will be available. How necessary is it to organize the deployment of documentation with previous versions?