### PR TITLE
g_spoint3_fetch was already part of the spoint3 opclass in older vers…

### DIFF
--- a/upgrade_scripts/pg_sphere--1.3.1--1.3.2.sql.in
+++ b/upgrade_scripts/pg_sphere--1.3.1--1.3.2.sql.in
@@ -1,4 +1,14 @@
 -- add "fetch" support function to enable index-only scans for spoint3
 
-ALTER OPERATOR FAMILY spoint3 USING gist ADD
-   FUNCTION 9 (spoint, spoint) g_spoint3_fetch (internal);
+-- g_spoint3_fetch was already part of the spoint3 opclass in older versions
+-- around 1.0, but later made optional (see bdc37d1)
+
+DO $$
+BEGIN
+   ALTER OPERATOR FAMILY spoint3 USING gist ADD
+      FUNCTION 9 (spoint, spoint) g_spoint3_fetch (internal);
+EXCEPTION
+   WHEN duplicate_object THEN NULL;
+   WHEN OTHERS THEN RAISE;
+END;
+$$;


### PR DESCRIPTION
…ions

Allow upgrading of older installations (made pre 1.1.5) that already have g_spoint3_fetch in the spoint3 opclass.

Close #82.