### PR TITLE
spherepoint_hash32: float8 needs wrapping into a Datum

### DIFF
--- a/src/point.c
+++ b/src/point.c
@@ -315,8 +315,8 @@ Datum
 spherepoint_hash32(PG_FUNCTION_ARGS)
 {
 	SPoint	   *p1 = (SPoint *) PG_GETARG_POINTER(0);
-	Datum		h1 = DirectFunctionCall1(hashfloat8, p1->lat);
-	Datum		h2 = DirectFunctionCall1(hashfloat8, p1->lng);
+	Datum		h1 = DirectFunctionCall1(hashfloat8, Float8GetDatum(p1->lat));
+	Datum		h2 = DirectFunctionCall1(hashfloat8, Float8GetDatum(p1->lng));
 
 	PG_RETURN_INT32(DatumGetInt32(h1) ^ DatumGetInt32(h2));
 }


### PR DESCRIPTION
Sorry I forgot to test on 32-bit... The new spherepoint_hash32 function crashes on platforms where float8 is passed by pointer.