### PR TITLE
fix Makefile dist target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ else
 	@$(missing) flex $< $@
 endif
 
-dist : clean sparse.c sscan.c
+dist : clean
 	find . -name '*~' -type f -exec rm {} \;
 	cd .. && tar --transform s/$(SRC_DIR)/pgsphere-$(PGSPHERE_VERSION)/ --exclude CVS --exclude .git -czf pgsphere-$(PGSPHERE_VERSION).tar.gz $(SRC_DIR) && cd -
 


### PR DESCRIPTION
the sparse.c and sscan.c files are now committed in src dir

I use the dist target to create tarballs as part of building rpm packages.