### PR TITLE
Fix upgrade script generation from 1.5.1 to 1.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ DATA_built  = $(RELEASE_SQL) \
 			  pg_sphere--1.4.0--1.4.1.sql \
 			  pg_sphere--1.4.1--1.4.2.sql \
 			  pg_sphere--1.4.2--1.5.0.sql \
-			  pg_sphere--1.5.0--1.5.1.sql
+			  pg_sphere--1.5.0--1.5.1.sql \
+			  pg_sphere--1.5.1--1.5.2.sql
 
 DOCS        = README.pg_sphere COPYRIGHT.pg_sphere
 TESTS       = version tables points euler circle line ellipse poly path box \


### PR DESCRIPTION
During the upgrade testing it was found, that the upgrade script was not generated. The upgrade to 1.5.2 was failed. The patch fixes the generation of the upgrade script.